### PR TITLE
Swap logo media sizes

### DIFF
--- a/_includes/components/hero.html
+++ b/_includes/components/hero.html
@@ -37,9 +37,9 @@
       <div class="hero-overlay">
         <picture class="hero-logo">
           <source
-            media="(min-width: 640px)"
-            srcset="{{ site.baseurl }}/assets/img/dist/jobkit_logo_wht.svg">
-            <img src="{{ site.baseurl }}/assets/img/dist/jobkit_logo_text.svg">
+            media="(max-width: 640px)"
+            srcset="{{ site.baseurl }}/assets/img/dist/jobkit_logo_text.svg">
+          <img src="{{ site.baseurl }}/assets/img/dist/jobkit_logo_wht.svg">
         </picture>
 
         <hr class="border-top-1 border-secondary margin-left-neg-3px width-tablet">


### PR DESCRIPTION

IE ignores the `picure` `source` and will just default to showing the `img` so it was displaying the larger mobile logo only. This was bumping down the `Documentation` button too far so I swapped these logo/size choices. 